### PR TITLE
Remove incorrect double colon from example git clone commands

### DIFF
--- a/BLANK_README.md
+++ b/BLANK_README.md
@@ -108,7 +108,7 @@ npm install npm@latest -g
  
 1. Clone the repo
 ```sh
-git clone https:://github.com/github_username/repo.git
+git clone https://github.com/github_username/repo.git
 ```
 2. Install NPM packages
 ```sh

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ npm install npm@latest -g
 1. Get a free API Key at [https://example.com](https://example.com)
 2. Clone the repo
 ```sh
-git clone https:://github.com/your_username_/Project-Name.git
+git clone https://github.com/your_username_/Project-Name.git
 ```
 3. Install NPM packages
 ```sh


### PR DESCRIPTION
The example git clone command under the "Installation" section uses two colons after _https_ instead of one, which is invalid. I corrected this in both the README.md and BLANK_README.md to avoid confusion.