### PR TITLE
updated alignment tags in readme and blank readme 

### DIFF
--- a/BLANK_README.md
+++ b/BLANK_README.md
@@ -31,7 +31,7 @@
 
 <!-- PROJECT LOGO -->
 <br />
-<p align="center">
+<div align="center">
   <a href="https://github.com/github_username/repo_name">
     <img src="images/logo.png" alt="Logo" width="80" height="80">
   </a>
@@ -50,7 +50,7 @@
     ·
     <a href="https://github.com/github_username/repo_name/issues">Request Feature</a>
   </p>
-</p>
+</div>
 
 
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 <!-- PROJECT LOGO -->
 <br />
-<p align="center">
+<div align="center">
   <a href="https://github.com/othneildrew/Best-README-Template">
     <img src="images/logo.png" alt="Logo" width="80" height="80">
   </a>
@@ -45,7 +45,7 @@
     ·
     <a href="https://github.com/othneildrew/Best-README-Template/issues">Request Feature</a>
   </p>
-</p>
+</div>
 
 
 


### PR DESCRIPTION
GitLab's markdown doesn't respect alignment in `<p>` tags, and any project that uses this template ends up with a left justified title block. Replacing `<p align="center">` with `<div align="center">` fixes the issue.

This also fixes a separate issue where any Jetbrains IDE (Pycharm, IntelliJ, CLion) would flagged an error with the closing `</p>` tag of the title block saying it matches nothing. and every time you'd try and commit changes there'd be an annoying pop-up saying as much.

## With `<p>` tags
![image](https://user-images.githubusercontent.com/9340751/120861676-a836fc80-c555-11eb-9408-7eb969d3def4.png)

## With `<div>` tags
![image](https://user-images.githubusercontent.com/9340751/120861702-b4bb5500-c555-11eb-899e-230ea7350889.png)
