### PR TITLE
Fixed screenshot markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@
 <!-- ABOUT THE PROJECT -->
 ## About The Project
 
-[![Product Name Screen Shot][product-screenshot]](https://example.com)
+![Product Name Screen Shot][product-screenshot]](https://example.com)
 
 There are many great README templates available on GitHub, however, I didn't find one that really suit my needs so I created this enhanced one. I want to create a README template so amazing that it'll be the last one you ever need -- I think this is it.
 


### PR DESCRIPTION
There seemed to be an unnecessary '[' before the '![Product Name Screen Shot][product-screenshot]](https://example.com)' that was breaking the image when I cloned it down locally.