### PR TITLE
added link to github.com/Envoy-VC/awesome-badges in code comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Use the `BLANK_README.md` to get started.
 ### Built With
 
 This section should list any major frameworks/libraries used to bootstrap your project. Leave any add-ons/plugins for the acknowledgements section. Here are a few examples.
+<!-- See for a more examples: https://github.com/Envoy-VC/awesome-badges -->
 
 * [![Next][Next.js]][Next-url]
 * [![React][React.js]][React-url]


### PR DESCRIPTION
Added a comment in the code with a link to https://github.com/Envoy-VC/awesome-badges. 

The reason is that it took me a long time to find additional examples of these badges. As your repo is all about saving time for devs, I thought it might be a good inclusion. 