### PR TITLE
Fix: Update deprecated name attribute to id for "Back to top" link

### DIFF
--- a/BLANK_README.md
+++ b/BLANK_README.md
@@ -1,5 +1,5 @@
 <!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
-<a name="readme-top"></a>
+<a id="readme-top"></a>
 <!--
 *** Thanks for checking out the Best-README-Template. If you have a suggestion
 *** that would make this better, please fork the repo and create a pull request

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
-<a name="readme-top"></a>
+<a id="readme-top"></a>
 <!--
 *** Thanks for checking out the Best-README-Template. If you have a suggestion
 *** that would make this better, please fork the repo and create a pull request


### PR DESCRIPTION
This pull request fixes the "Back to top" link in the markdown file by replacing the deprecated name attribute with the id attribute. This change ensures the link functions correctly in modern browsers.

Changes Made:
Replaced <a name="readme-top"></a> with <a id="readme-top"></a>.

Reason for the Change:
The name attribute is deprecated in HTML5. Using the id attribute ensures compatibility with current web standards.
