### PR TITLE
Fix character encoding issue

### DIFF
--- a/BLANK_README.md
+++ b/BLANK_README.md
@@ -43,9 +43,9 @@
     <br />
     <br />
     <a href="https://github.com/github_username/repo_name">View Demo</a>
-    ·
+    &middot;
     <a href="https://github.com/github_username/repo_name/issues/new?labels=bug&template=bug-report---.md">Report Bug</a>
-    ·
+    &middot;
     <a href="https://github.com/github_username/repo_name/issues/new?labels=enhancement&template=feature-request---.md">Request Feature</a>
   </p>
 </div>

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@
     <br />
     <br />
     <a href="https://github.com/othneildrew/Best-README-Template">View Demo</a>
-    ·
+    &middot;
     <a href="https://github.com/othneildrew/Best-README-Template/issues/new?labels=bug&template=bug-report---.md">Report Bug</a>
-    ·
+    &middot;
     <a href="https://github.com/othneildrew/Best-README-Template/issues/new?labels=enhancement&template=feature-request---.md">Request Feature</a>
   </p>
 </div>


### PR DESCRIPTION
Issue:
When I uploaded the template to PyPI, there was an encoding issue where the middot character (·) was misrendered as Â·. Here's a preview of the issue: https://imgcdn.dev/i/pzE5y.

Fix:
I replaced the middot character (·) with its HTML entity (&middot). This ensures proper rendering on both GitHub and PyPI, and it should also resolve the issue on any other platform that doesn't fully support UTF-8 encoded characters.

Result:
The middot character now displays correctly on both Github and PyPI platforms.