### PR TITLE
Fix grammar: add missing 'who' in contribution thanks line

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Here's why:
 * You shouldn't be doing the same tasks over and over like creating a README from scratch
 * You should implement DRY principles to the rest of your life :smile:
 
-Of course, no one template will serve all projects since your needs may be different. So I'll be adding more in the near future. You may also suggest changes by forking this repo and creating a pull request or opening an issue. Thanks to all the people have contributed to expanding this template!
+Of course, no one template will serve all projects since your needs may be different. So I'll be adding more in the near future. You may also suggest changes by forking this repo and creating a pull request or opening an issue. Thanks to all the people who have contributed to expanding this template!
 
 Use the `BLANK_README.md` to get started.
 


### PR DESCRIPTION
Fixes a small grammar issue in the README: adds the missing relative pronoun 'who' in the line thanking contributors. This makes the sentence grammatically correct.